### PR TITLE
Window.close not converting bool to c_int

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -181,7 +181,7 @@ pub fn shouldClose(self: Window) bool {
 /// synchronized.
 pub fn close(self: Window, value: bool) void {
     requireInit();
-    self.handle.shouldClose = value;
+    self.handle.shouldClose = @intFromBool(value);
 }
 
 /// This function gets the window title, encoded as UTF-8, of the specified window.


### PR DESCRIPTION
Window.close function takes in a boolean, but doesn't convert it back to c_int before assigning causing a compile error.