### PR TITLE
Fix syntax errors in untested functions and force syntax analysis when testing 

### DIFF
--- a/src/GammaRamp.zig
+++ b/src/GammaRamp.zig
@@ -16,7 +16,7 @@ owned: ?[]u16,
 /// Initializes a new (owned) gamma ramp with the given size and undefined values
 /// .deinit must be called.
 pub fn init(allocator: std.mem.Allocator, size: usize) !GammaRamp {
-    const buf = try allocator.init(u16, size * 3);
+    const buf = try allocator.alloc(u16, size * 3);
     return .{
         .red = buf[0..size],
         .green = buf[size .. 2 * size],

--- a/src/Joystick.zig
+++ b/src/Joystick.zig
@@ -285,7 +285,7 @@ pub fn getGUID(self: Joystick) ?[]const u8 {
 /// @thread_safety This function may be called from any thread. Access is not synchronized.
 pub fn setUserPointer(self: Joystick, ptr: ?*anyopaque) void {
     requireInit();
-    if (self.handle.allocated == 0) return null;
+    if (self.handle.allocated == 0) return;
     self.handle.userPointer = ptr;
 }
 

--- a/src/Joystick.zig
+++ b/src/Joystick.zig
@@ -356,7 +356,7 @@ pub inline fn setCallback(comptime callback: ?fn (joystick: Joystick, event: Eve
 ///
 ///
 /// @thread_safety This function must only be called from the main thread.
-pub fn updateGamepadMappings(string: []const u8) GamepadError!void {
+pub fn updateGamepadMappings(string: [:0]const u8) GamepadError!void {
     requireInit();
     _ = c.glfwUpdateGamepadMappings(string);
     try internal.subErrorCheck(GamepadError);

--- a/src/Monitor.zig
+++ b/src/Monitor.zig
@@ -15,7 +15,7 @@ handle: *_c._GLFWmonitor = undefined,
 ///
 /// Generates a glfw.Monitor given a C pointer to a monitor
 pub fn init(glfw_handle: *c.GLFWmonitor) Monitor {
-    return .{ .handle = glfw_handle };
+    return .{ .handle = @alignCast(@ptrCast(glfw_handle)) };
 }
 
 /// Returns the currently connected monitors.

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1595,7 +1595,7 @@ pub inline fn setDropCallback(self: Window, comptime callback: ?fn (window: Wind
 
 pub fn swapBuffers(self: Window) !void {
     requireInit();
-    if (self.handle.context.client == @intFromEnum(glfw.Hint.Context.API.Client.Value.NoAPI))
+    if (self.handle.context.client == @intFromEnum(Hints.Context.ClientAPI.none))
         return Error.NoWindowContext;
 
     self.handle.context.swapBuffers(self.handle);

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1598,7 +1598,7 @@ pub fn swapBuffers(self: Window) !void {
     if (self.handle.context.client == @intFromEnum(Hints.Context.ClientAPI.none))
         return Error.NoWindowContext;
 
-    self.handle.context.swapBuffers(self.handle);
+    self.handle.context.swapBuffers.?(self.handle);
 }
 //
 // Hints

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -237,7 +237,7 @@ pub fn setTitle(self: Window, title: [:0]const u8) !void {
 const IFPError = error{ InvalidValue, FeatureUnavailable, PlatformError };
 pub fn setIcon(self: Window, images: []const c.GLFWimage) IFPError!void {
     requireInit();
-    c.glfwSetWindowIcon(@ptrCast(self.handle), images.len, images);
+    c.glfwSetWindowIcon(@ptrCast(self.handle), @intCast(images.len), images.ptr);
     try internal.subErrorCheck(IFPError);
 }
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -7,7 +7,15 @@ test "glfw init hits" {
     var hints: glfw.InitHints = .{};
     hints.joystick_hat_buttons = false;
     hints.cocoa.menubar = true;
+
+    std.testing.refAllDecls(glfw.InitHints);
 }
+
+test "force syntax evaluation" {
+    std.testing.refAllDecls(glfw);
+    std.testing.refAllDecls(glfw.GammaRamp);
+}
+
 test "glfw version" {
     var major: c_int = 0;
     var minor: c_int = 0;
@@ -80,6 +88,8 @@ test "glfw monitor" {
     if (res) |ramp| {
         try primary.setGammaRamp(ramp);
     }
+
+    std.testing.refAllDecls(glfw.Monitor);
 }
 test "glfw window" {
     try glfw.init(.{});
@@ -224,6 +234,7 @@ test "glfw window" {
             _ = glfw.getProcAddress("glSpecializeShaderARB");
         }
     }
+    std.testing.refAllDecls(glfw.Window);
 }
 
 test "glfw input" {
@@ -262,6 +273,9 @@ test "glfw input" {
     try expect(t < 0.01);
     _ = glfw.getTimerValue();
     _ = glfw.getTimerFrequency();
+
+    std.testing.refAllDecls(glfw.Input);
+    std.testing.refAllDecls(glfw.Joystick);
 }
 
 test "glfw vulkan" {


### PR DESCRIPTION
Initially the following program would not compile
```zig
const std = @import("std");
const zlfw = @import("zlfw");

pub fn main() !void {
    try zlfw.init(.{});
    defer zlfw.deinit();

    const window = try zlfw.Window.init(800, 480, "zulkan", null, null, .{});
    defer window.deinit();

    while (!window.shouldClose()) {
        zlfw.pollEvents();

        try window.swapBuffers();
    }
}
```
.. since Window.swapBuffers referenced non-existent enum Hints from `module.zig`

By using `std.testing.refAllDecls` I found that there are more errors that make similar mistakes. This PR fixes them.

I am hesitant on using `std.testing.refAllDeclsRecursive` since that references declarations in C translation modules which contain `@compileError` on some declarations.

Also be wary that as of writing this PR, `usingnamespace` has been removed from Zig language. https://github.com/ziglang/zig/commit/fc2c1883b36a6ba8c7303d12b57147656dc7dd70 